### PR TITLE
[FIX] corrects include destination directory when used outside ROS

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -97,6 +97,6 @@ else()
   install(TARGETS ${PROJECT_NAME}
           LIBRARY DESTINATION lib
           ARCHIVE DESTINATION lib)
-  install(DIRECTORY include/${PROJECT_NAME}/
+  install(DIRECTORY include/
           DESTINATION include)
 endif()


### PR DESCRIPTION
The include files where deployed in ${CMAKE_INSTALL_PREFIX]/include instead of ${CMAKE_INSTALL_PREFIX]/include/kdl_parser